### PR TITLE
Fix dataset descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "algoseek-connector"
-version = "2.1.0"
+version = "2.1.1"
 description = "A wrapper library for ORM-like SQL builder and executor"
 authors = [
     "Taras Kuzyo <taras@algoseek.com>",

--- a/src/algoseek_connector/base.py
+++ b/src/algoseek_connector/base.py
@@ -925,7 +925,9 @@ class DescriptionProvider(Protocol):
         """Get the description of a dataset."""
 
     @abstractmethod
-    def get_columns_description(self, dataset: str) -> list[ColumnDescription]:
+    def get_columns_description(
+        self, group: str, dataset: str
+    ) -> list[ColumnDescription]:
         """Get the description of columns in a dataset."""
 
 

--- a/src/algoseek_connector/clickhouse/client.py
+++ b/src/algoseek_connector/clickhouse/client.py
@@ -384,6 +384,12 @@ class ArdaDBDescriptionProvider(base.DescriptionProvider):
                 group_dict[ardadb_dataset] = dataset
         return res
 
+    def _get_api_data_group_text_id(self, ardadb_group: str) -> str:
+        return self._ardadb_group_to_api_group()[ardadb_group]
+
+    def _get_api_dataset_text_id(self, ardadb_group: str, ardadb_dataset: str) -> str:
+        return self._ardadb_dataset_to_api_dataset()[ardadb_group][ardadb_dataset]
+
     def get_datagroup_description(self, group: str) -> base.DataGroupDescription:
         """
         Get the description of a datagroup.
@@ -399,7 +405,7 @@ class ArdaDBDescriptionProvider(base.DescriptionProvider):
 
         """
         try:
-            group_text_id = self._ardadb_group_to_api_group()[group]
+            group_text_id = self._get_api_data_group_text_id(group)
             datagroup_metadata = self._api.get_datagroup_metadata(group_text_id)
             display_name = datagroup_metadata["display_name"]
             description = datagroup_metadata["description"]
@@ -425,8 +431,7 @@ class ArdaDBDescriptionProvider(base.DescriptionProvider):
 
         """
         try:
-            group_datasets = self._ardadb_dataset_to_api_dataset()[group]
-            dataset_text_id = group_datasets[dataset]
+            dataset_text_id = self._get_api_dataset_text_id(group, dataset)
             dataset_metadata = self._api.get_dataset_metadata(dataset_text_id)
             db_metadata = dataset_metadata["database_table"]
             columns = list()

--- a/src/algoseek_connector/metadata_api.py
+++ b/src/algoseek_connector/metadata_api.py
@@ -391,5 +391,5 @@ def _get_login_metadata(user: str, password: str, url: str, **kwargs) -> dict[st
     if response.status_code == requests.codes.OK:
         return response.json()
     else:
-        msg = "Login failed with code {response.status_code}"
+        msg = f"Login failed with code {response.status_code}"
         raise requests.HTTPError(msg)

--- a/src/algoseek_connector/metadata_api.py
+++ b/src/algoseek_connector/metadata_api.py
@@ -121,7 +121,10 @@ class BaseAPIConsumer:
         """
         endpoint = "public/data_group/"
         response = self.get(endpoint)
-        return {x["text_id"]: x for x in response.json()}
+        metadata = {x["text_id"]: x for x in response.json()}
+        # TODO: delete once etf/etn is removed from metadata API
+        metadata.pop("us_etf_etn")
+        return metadata
 
     @lru_cache
     def _fetch_dataset_platform_metadata(self) -> dict[str, dict]:

--- a/src/algoseek_connector/s3/client.py
+++ b/src/algoseek_connector/s3/client.py
@@ -206,7 +206,9 @@ class S3DescriptionProvider(base.DescriptionProvider):
             display_name = group
         return base.DataGroupDescription(group, description, display_name)
 
-    def get_columns_description(self, dataset: str) -> list[base.ColumnDescription]:
+    def get_columns_description(
+        self, group: str, dataset: str
+    ) -> list[base.ColumnDescription]:
         """
         Get the description of the dataset columns.
 
@@ -253,7 +255,7 @@ class S3DescriptionProvider(base.DescriptionProvider):
         InvalidDataSetName
 
         """
-        columns = self.get_columns_description(dataset)
+        columns = self.get_columns_description(group, dataset)
         try:
             dataset_metadata = self._api.get_dataset_metadata(dataset)
             display_name = dataset_metadata["display_name"]

--- a/tests/integration/clickhouse/test_clickhouse_client.py
+++ b/tests/integration/clickhouse/test_clickhouse_client.py
@@ -244,3 +244,42 @@ def test_ClickHouseClient_store_to_s3_overwrite_raises_error(
     s3_client = s3.downloader.get_s3_client(boto3_session)
     bucket = s3.downloader.BucketWrapper(s3_client, bucket)
     bucket.delete_file(key)
+
+
+@pytest.mark.parametrize(
+    "ardadb_group,api_group",
+    [
+        ("USEquityMarketData", "us_equity"),
+        ("USEquityReferenceData", "us_equity_ref"),
+        ("USFuturesMarketData", "cme_futures"),
+    ],
+)
+def test_ArdaDBDescriptionProvider_get_api_group_text_id(
+    data_source: DataSource, ardadb_group, api_group
+):
+    description_provider = cast(
+        ArdaDBDescriptionProvider, data_source.description_provider
+    )
+    actual = description_provider._get_api_data_group_text_id(ardadb_group)
+    assert actual == api_group
+
+
+@pytest.mark.parametrize(
+    "ardadb_group,ardadb_dataset,dataset_text_id",
+    [
+        ("USEquityMarketData", "TradeAndQuote", "eq_taq"),
+        ("USEquityMarketData", "TradeOnly", "eq_trades"),
+        ("USEquityReferenceData", "BasicAdjustments", "eq_adj_factors_basic"),
+    ],
+)
+def test_ArdaDBDescriptionProvider_get_api_dataset_text_id(
+    data_source: DataSource,
+    ardadb_group: str,
+    ardadb_dataset: str,
+    dataset_text_id: str,
+):
+    description_provider = cast(
+        ArdaDBDescriptionProvider, data_source.description_provider
+    )
+    actual = description_provider._get_api_dataset_text_id(ardadb_group, ardadb_dataset)
+    assert actual == dataset_text_id

--- a/tests/integration/s3/test_client.py
+++ b/tests/integration/s3/test_client.py
@@ -137,8 +137,11 @@ def description_provider(api: BaseAPIConsumer):
 def test_S3DescriptionProvider_get_columns_description(
     description_provider: S3DescriptionProvider,
 ):
-    text_id = "eq_taq_1min"
-    actual = description_provider.get_columns_description(text_id)
+    group_text_id = "us_equity"
+    dataset_text_id = "eq_taq_1min"
+    actual = description_provider.get_columns_description(
+        group_text_id, dataset_text_id
+    )
     assert len(actual)
     assert all(isinstance(x, ac.base.ColumnDescription) for x in actual)
 
@@ -146,8 +149,11 @@ def test_S3DescriptionProvider_get_columns_description(
 def test_S3DescriptionProvider_get_columns_description_non_existent_returns_empty_list(
     description_provider: S3DescriptionProvider,
 ):
-    text_id = "NonExistentDataSet"
-    actual = description_provider.get_columns_description(text_id)
+    group_text_id = "us_equity"
+    dataset_text_id = "NonExistentDataSet"
+    actual = description_provider.get_columns_description(
+        group_text_id, dataset_text_id
+    )
     assert not actual
 
 


### PR DESCRIPTION
This PR solves two bugs associated with dataset descriptions:

- Ignore legacy datasets
- Incorrect dataset descriptions when multiple datasets in different data groups share the same name.